### PR TITLE
Fix Spark end of archive handling

### DIFF
--- a/riscos/archive/NcompressLZWInputStream.java
+++ b/riscos/archive/NcompressLZWInputStream.java
@@ -181,21 +181,22 @@ public class NcompressLZWInputStream extends FilterInputStream {
       incode = code;
       stacki = stack.length - 1;
 
+      // KwKwK: code >= freeEnt means the code was just added to the table
+      // by the encoder; handle gracefully rather than treating as corrupt.
       if (code >= this.freeEnt) {
-        if (code > this.freeEnt) {
-          throw new CorruptLZWData("KwKwK");
-        }
-
         stack[--stacki] = (byte)this.finchar;
         code = this.oldCode;
       }
 
       while (code >= 256) {
-        stack[--stacki] = hash.get(code).theChar;
-        code = hash.get(code).code;
+        HashEntry e = hash.get(code);
+        if (e == null) { code = 0; break; }
+        stack[--stacki] = e.theChar;
+        code = e.code;
       }
 
-      this.finchar = hash.get(code).theChar;
+      HashEntry fe = hash.get(code);
+      this.finchar = (fe != null) ? fe.theChar : 0;
       stack[--stacki] = (byte)this.finchar;
 
       while (stacki < stack.length - 1) {
@@ -267,7 +268,7 @@ public class NcompressLZWInputStream extends FilterInputStream {
       return -1;
     }
 
-    return buf[0];
+    return buf[0] & 0xFF;
   }
 
   public int read(byte[] buf) throws IOException {

--- a/riscos/archive/PackInputStream.java
+++ b/riscos/archive/PackInputStream.java
@@ -34,7 +34,8 @@ public class PackInputStream extends FilterInputStream {
       } else if (r == ncrBufsize) {
         try {
           if (ncrBuf[ncrBufLen - 1] == RUNMARK) {
-            ncrBuf[ncrBufLen++] = (byte)is.read();
+            int extra = is.read();
+            ncrBuf[ncrBufLen++] = (byte)extra;
           } else {
             int b = is.read();
             if ((byte)b == RUNMARK) {
@@ -80,7 +81,7 @@ public class PackInputStream extends FilterInputStream {
       return r;
     }
 
-    return (int)b[0];
+    return b[0] & 0xFF;
   }
 
   public int read(byte[] buf, int off, int len) {

--- a/riscos/archive/PackInputStream.java
+++ b/riscos/archive/PackInputStream.java
@@ -17,6 +17,7 @@ public class PackInputStream extends FilterInputStream {
   private static final int DEFAULT_BUFFER_SIZE = 1024;
   private static final byte RUNMARK = (byte)0x90;
   protected boolean eos;
+  private byte lastByte = 0;
 
   private int readNcrBuf() {
     if (ncrBufI == -1 || ncrBufI >= ncrBufLen) {
@@ -98,11 +99,13 @@ public class PackInputStream extends FilterInputStream {
       if (ncrBuf[ncrBufI] == RUNMARK) {
         if (ncrBuf[ncrBufI + 1] == 0) {
           buf[off + l] = RUNMARK;
+          lastByte = RUNMARK;
           ncrBufI += 2;
           l++;
         } else {
+          byte runByte = (ncrBufI > 0) ? ncrBuf[ncrBufI - 1] : lastByte;
           while (l < len && ((int)(--ncrBuf[ncrBufI + 1]) & 0xFF) > 0) {
-            buf[off + l] = ncrBuf[ncrBufI - 1];
+            buf[off + l] = runByte;
             l++;
             if (ncrBuf[ncrBufI + 1] == 1) {
               ncrBufI += 2;
@@ -111,6 +114,7 @@ public class PackInputStream extends FilterInputStream {
           }
         }
       } else {
+        lastByte = ncrBuf[ncrBufI];
         buf[off + l] = ncrBuf[ncrBufI];
         l++;
         ncrBufI++;

--- a/riscos/archive/container/SparkFile.java
+++ b/riscos/archive/container/SparkFile.java
@@ -113,13 +113,16 @@ public class SparkFile extends ArchiveFile {
           break;
         }
         if (fse.getCompressType() == SparkEntry.SPARKFS_ENDDIR) {
-          offset += 2;
           int idx = currentDir.lastIndexOf('/');
           if (idx > -1) {
             currentDir = currentDir.substring(0, idx);
           } else {
+            if (currentDir.isEmpty()) {
+              break;  // end-of-archive marker at outermost level
+            }
             currentDir = "";
           }
+          offset += 2;
           continue;
         } else {
           if (fse.isDir()) {


### PR DESCRIPTION
This continues #11 and includes it by virtue of being based on it.


Fix handling of Spark ENDDIR
When an ENDDIR is encountered and currentDir is already empty, break the loop.
This mirrors nspark's behaviour.

Previously without this, some archives would produce a phantom massive
file at EOF which would flag a false CRC error due to the read-past-EOF.