### PR TITLE
Properly handle CFS files with truncated ENDBLOCKs

### DIFF
--- a/riscos/archive/CFSInputStream.java
+++ b/riscos/archive/CFSInputStream.java
@@ -187,9 +187,14 @@ public class CFSInputStream extends FilterInputStream {
         this.blocktype = ENDBLOCK;
         return;
       }
-      this.codelimit = getChar();
-      this.codelimit |= getChar() << 8;
-      this.codelimit |= getChar() << 16;
+      int cl0 = getChar();
+      int cl1 = getChar();
+      int cl2 = getChar();
+      if (cl0 == -1 || cl1 == -1 || cl2 == -1) {
+        this.blocktype = ENDBLOCK;
+        return;
+      }
+      this.codelimit = cl0 | (cl1 << 8) | (cl2 << 16);
       if (this.blocktype == COMPRESSEDBLOCK) {
         this.codelimit += 0xff;
       }


### PR DESCRIPTION
Fixes #10.

Some CFS files (like the "Text" file attached to #10) only have one byte after the ENDBLOCK marker. This tweaks the CFS loader so that hitting the EOF (which makes read() return -1) doesn't cause a crash.