### PR TITLE
Fix ArcFS zero-length file directory mis-detection

### DIFF
--- a/riscos/archive/container/ArcFSEntry.java
+++ b/riscos/archive/container/ArcFSEntry.java
@@ -65,11 +65,9 @@ public class ArcFSEntry extends ArchiveEntry {
     complen = arcFile.read32();
     int infoWord = arcFile.read32();
     seek = (infoWord & 0x7fffffff) + dataStart;
-    if (((infoWord >> 31) & 0x1) != 0) {
-      isDir = true;
-    } else {
-      isDir = false;
-    }
+    isDir = ((infoWord & 0x80000000) != 0)
+        && origlen == 0xffffffff
+        && complen == 0xffffffff;
     appendFiletype();
     calculateFileTime();
     nextEntryOffset = inFile.getFilePointer();


### PR DESCRIPTION
This one pops up on RISC Disc 2, in the file `$.PD_SHARE.MAGS.NEWDAWN`

This archive contains a bunch of directories under `!New_Dawn.Text` which contain seven numbered text files each. Generally each only has one or two files with actual text and the rest are zero-length.

Riscosarc (and indeed Nspark) incorrectly identify the zero-length text files as directories, which then erroneously get pushed onto the path, never to be popped. The outcome is you get absurd, long directory paths like:

```
!New_Dawn/Text/Articles/1914HELP/3/4/5/6/3dck/2/3/4/5/6/ainfo/2/3/4/5/6/Amiga/2/3/4/5/6/AMIGA-ARC/4/5/6/ARTINFO/2/3/4/5/6/ASTUTE/3/4/5/6/CHEATS/4/5/6/CONTRIBS/4/5/6/Datafile/2/3/4/5/6/EDITORIAL/4/5/6/factfile/3/4/5/6/gameinfo/2/3/4/5/6/geninfo/2/3/4/5/6/GINFO/2/3/4/5/6/hintsinfo/2/3/4/5/6/maininfo/3/4/5/6/megademo/2/3/4/5/6/multimedia/5/6/music/5/6/NARC/3/4/5/6/PAINT/4/5/6/QINFO/2/3/4/5/6/qsoftware/quotes/6/s42/6/sinfo/2/3/4/5/6/softinfo/2/3/4/5/6/SOUNDS/6/sylphHELP/2/3/4/5/6/Tom's/3/4/Illusion
```

When the real path is more like `!New_Dawn/Text/Articles/Illusion`.

The key is that directories have `origlen = complen = 0xFFFFFFFF` - so we use that to detect them. I have no idea if the info word is part of directory detection -- I don't think Mark Smith fully documented the ArcFS file format and he certainly never released the ArcFS source code.

I've spot-checked against a couple of other ArcFS archives and this logic seems to hold for them too.

Incidentally Nspark has the same bug!