### PR TITLE
Fix Spark archives being truncated at a nested archive-typed file

### DIFF
--- a/riscos/archive/RandomAccessInputStream.java
+++ b/riscos/archive/RandomAccessInputStream.java
@@ -42,6 +42,10 @@ public class RandomAccessInputStream extends InputStream {
     return raf.skipBytes((int)bytesToSkip);
   }
 
+  public long length() throws IOException {
+    return raf.length();
+  }
+
   public long getFilePointer() throws IOException {
     return raf.getFilePointer();
   }

--- a/riscos/archive/container/SparkEntry.java
+++ b/riscos/archive/container/SparkEntry.java
@@ -142,6 +142,14 @@ public class SparkEntry extends ArchiveEntry {
     return isEof;
   }
 
+  /** Reinterprets a directory entry as a plain file. Used when the entry's
+   * contents turn out not to be a directory after all.
+   */
+  public void demoteToFile() {
+    isDir = false;
+    nextEntyOffset = seek + complen + 1;
+  }
+
   public long getNextEntryOffset() {
     return nextEntyOffset;
   }

--- a/riscos/archive/container/SparkEntry.java
+++ b/riscos/archive/container/SparkEntry.java
@@ -33,12 +33,16 @@ public class SparkEntry extends ArchiveEntry {
     isEof = false;
   }
 
-  /* Directories carry the RISC OS "archive" filetype (&DDC), and so do plain
-   * files which happen to be archives themselves -- the two are identical as
-   * far as the entry header goes. A directory's data is a run of Spark
-   * entries, so peek at the first byte and only believe the filetype if it
-   * looks like the start of one. */
-  private boolean dataStartsWithEntry() throws IOException {
+  /* A directory's data is a plain, uncompressed run of Spark entries, and it
+   * carries the RISC OS "archive" filetype (&DDC). So does a plain file which
+   * happens to be an archive itself though, and for a stored one the entry
+   * headers are then identical -- so also peek at the first byte of the data
+   * and only believe the filetype if it looks like the start of an entry. */
+  private boolean isDirectoryEntry() throws IOException {
+    if (comptype != SparkFile.CT_NOTCOMP2 || (load & 0xffffff00) != 0xfffddc00) {
+      return false;
+    }
+
     long pos = inFile.getFilePointer();
     int b = inFile.read();
     inFile.seek(pos);
@@ -104,7 +108,7 @@ public class SparkEntry extends ArchiveEntry {
     }
     comptype &= ~ARCHPACK;
     seek = (int)inFile.getFilePointer();
-    if ((load & 0xffffff00) == 0xfffddc00 && dataStartsWithEntry()) {
+    if (isDirectoryEntry()) {
       isDir = true;
     }
     if (isDir) {

--- a/riscos/archive/container/SparkEntry.java
+++ b/riscos/archive/container/SparkEntry.java
@@ -33,6 +33,19 @@ public class SparkEntry extends ArchiveEntry {
     isEof = false;
   }
 
+  /* Directories carry the RISC OS "archive" filetype (&DDC), and so do plain
+   * files which happen to be archives themselves -- the two are identical as
+   * far as the entry header goes. A directory's data is a run of Spark
+   * entries, so peek at the first byte and only believe the filetype if it
+   * looks like the start of one. */
+  private boolean dataStartsWithEntry() throws IOException {
+    long pos = inFile.getFilePointer();
+    int b = inFile.read();
+    inFile.seek(pos);
+
+    return b == SparkFile.SPARKFS_STARTBYTE;
+  }
+
   private void readSparkEntry(String curDir) throws IOException, InvalidSparkFile {
     int r = inFile.read();
 
@@ -91,7 +104,7 @@ public class SparkEntry extends ArchiveEntry {
     }
     comptype &= ~ARCHPACK;
     seek = (int)inFile.getFilePointer();
-    if ((load & 0xffffff00) == 0xfffddc00) {
+    if ((load & 0xffffff00) == 0xfffddc00 && dataStartsWithEntry()) {
       isDir = true;
     }
     if (isDir) {

--- a/riscos/archive/container/SparkFile.java
+++ b/riscos/archive/container/SparkFile.java
@@ -34,7 +34,8 @@ public class SparkFile extends ArchiveFile {
   public static final int CT_SQUASH = 0x09;
   public static final int CT_COMP = 0x7f;
 
-  private static final byte SPARKFS_STARTBYTE = 0x1a;
+  public static final int SPARKFS_STARTBYTE = 0x1a;
+
   private RandomAccessInputStream inFile;
   private String archiveFile;
   private int headerLength;

--- a/riscos/archive/container/SparkFile.java
+++ b/riscos/archive/container/SparkFile.java
@@ -18,6 +18,7 @@ import riscos.archive.UnsupportedLZWType;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayDeque;
 import java.util.Enumeration;
 import java.util.Vector;
 
@@ -100,48 +101,113 @@ public class SparkFile extends ArchiveFile {
     }
   }
 
+  /** A directory the scan has descended into, along with everything needed
+   * to back out of it again if its contents turn out to be something else.
+   */
+  private static class DirScan {
+    private final SparkEntry entry;
+    private final long endOffset;
+    private final int entryListMark;
+    private final String parentDir;
+
+    DirScan(SparkEntry entry, long endOffset, int entryListMark, String parentDir) {
+      this.entry = entry;
+      this.endOffset = endOffset;
+      this.entryListMark = entryListMark;
+      this.parentDir = parentDir;
+    }
+  }
+
+  /** Backs out of a directory whose contents did not match its recorded
+   * length, discards whatever was found inside it and reinterprets it as a
+   * plain file.
+   * @param dirStack the directories the scan is currently inside
+   * @return the offset to carry on scanning from
+   */
+  private long abandonDirectory(ArrayDeque<DirScan> dirStack) {
+    DirScan dir = dirStack.pop();
+
+    System.err.println("Warning: contents of '" + dir.entry.getName()
+        + "' do not match its recorded length, treating it as a file");
+
+    entryList.setSize(dir.entryListMark);
+    currentDir = dir.parentDir;
+    dir.entry.demoteToFile();
+    entryList.add(dir.entry);
+
+    return dir.entry.getNextEntryOffset();
+  }
+
   public void openForRead() throws IOException, InvalidArchiveFile {
     this.inFile = new RandomAccessInputStream(archiveFile);
+    long fileLength = inFile.length();
 
     readHeader();
 
+    ArrayDeque<DirScan> dirStack = new ArrayDeque<DirScan>();
     long offset = 1;
     do {
+      /* A directory entry records the length of its contents, so a scan
+       * which runs past that end has gone wrong -- either the archive is
+       * damaged, or the entry was never a directory in the first place.
+       * Unwind it rather than letting it derail the rest of the archive. */
+      if (!dirStack.isEmpty() && offset >= dirStack.peek().endOffset) {
+        offset = abandonDirectory(dirStack);
+        continue;
+      }
+
       SparkEntry fse = new SparkEntry(this, inFile, dataStart, appendFiletype);
       try {
         fse.readEntry(currentDir, offset);
-        if (fse.isEof()) {
-          break;
-        }
-        if (fse.getCompressType() == SparkEntry.SPARKFS_ENDDIR) {
-          int idx = currentDir.lastIndexOf('/');
-          if (idx > -1) {
-            currentDir = currentDir.substring(0, idx);
-          } else {
-            if (currentDir.isEmpty()) {
-              break;  // end-of-archive marker at outermost level
-            }
-            currentDir = "";
-          }
-          offset += 2;
-          continue;
-        } else {
-          if (fse.isDir()) {
-            if (currentDir != "") {
-              currentDir = currentDir + "/" + fse.getName();
-            } else {
-              currentDir = fse.getName();
-            }
-          } else {
-            entryList.add(fse);
-          }
-        }
-        offset = fse.getNextEntryOffset();
       } catch (Exception e) {
         System.err.println(e.toString());
+        if (dirStack.isEmpty()) {
+          break;
+        }
+        offset = abandonDirectory(dirStack);
+        continue;
+      }
+
+      if (fse.isEof()) {
         break;
       }
+
+      if (fse.getCompressType() == SparkEntry.SPARKFS_ENDDIR) {
+        if (dirStack.isEmpty()) {
+          break;  // end-of-archive marker at outermost level
+        }
+        offset += 2;
+        if (offset == dirStack.peek().endOffset) {
+          currentDir = dirStack.pop().parentDir;
+        } else {
+          offset = abandonDirectory(dirStack);
+        }
+        continue;
+      }
+
+      long dirEnd = fse.getNextEntryOffset() + fse.getCompressedLength();
+      if (fse.isDir() && dirEnd <= fileLength) {
+        dirStack.push(new DirScan(fse, dirEnd, entryList.size(), currentDir));
+        if (currentDir.isEmpty()) {
+          currentDir = fse.getName();
+        } else {
+          currentDir = currentDir + "/" + fse.getName();
+        }
+      } else {
+        if (fse.isDir()) {
+          /* Claims to be a directory, but its contents do not fit in the
+           * archive. */
+          fse.demoteToFile();
+        }
+        entryList.add(fse);
+      }
+      offset = fse.getNextEntryOffset();
     } while (true);
+
+    if (!dirStack.isEmpty()) {
+      System.err.println("Warning: archive ends inside directory '"
+          + dirStack.peek().entry.getName() + "'");
+    }
   }
 
   public void close() throws IOException {


### PR DESCRIPTION
An archive-typed (`&DDC`) *file* inside a Spark archive was mistaken for a directory, so the scanner parsed the file's contents as Spark entries. The junk entries that came back threw `InvalidSparkCompressionType` on extraction. Because any bad entry aborted the whole scan, everything after that point was silently dropped from the listing.

Found on a Spark archive (`Killer 1.900` from Arcarc) which contains an ArcFS archive stored as a file at `killer/CompDisc/Documents/AVRD/AVRD`.

Before this fix, 75 entries listed, 2 of them junk, and two `InvalidSparkCompressionType` traces on extraction.
After this fix: all 94 entries, exit 0.

The 21 lost entries included the entire `killer/Extras/` and `killer/RiscOS2/` subtrees.

## Cause

This is caused by Spark archives lacking a directory flag. A directory is instead marked by filetype `&DDC` (Archive); `SparkEntry` trusted that alone.

A genuine file which happens to be an archive has exactly the same filetype, and if it is Stored (not compressed) then its entry header is byte-identical to a directory's. There is no easy way to tell them apart from the header.

## Fix

The fix is layered on three commits:

  * Peek at the first byte of a file's data and only believe the filetype if it is the `0x1A` entry marker.
  * A directory entry records the length of its contents - keep a stack of directories and the offsets they end at. A scan which runs past that end now backs out of just that directory, reinterpreting it as a plain file, and carries on with the rest of the archive.
  * Adopt nspark's extra condition that an entry must also be *stored* (compression type 2) to be a directory, since a directory's contents are never compressed.

The first and last layers are both necessary: comptype rejects compressed `&DDC` files outright, while the start-byte check rejects stored ones whose headers are identical to a directory's (which nspark gets wrong).

## Other implementations

`nspark` has the same bug. It does sniff the `"Archive\0"` magic and switches to the ArcFS parser mid-stream, but then cannot get back out:

```
bad archive header
total of 1053781 bytes in 86 files
```

`lsar`/`unar` fails outright with: `Archive parsing failed! (Data is corrupted.)`.

This branch recovers the whole archive.